### PR TITLE
Fix the build with Python 3 and an external curl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,9 @@ except:
     defines.append(('NOCURL', None))
     sys.stderr.write("Either libcurl isn't installed, it didn't come with curl-config, or curl-config isn't in your $PATH. pyBigWig will be installed without support for remote files.\n")
 
-foo = foo.strip().split()
+foo = foo.decode().strip().split()
 for v in foo:
-    if(v[0:2] == "-L") :
+    if(v[0:2] == '-L') :
         additional_libs.append(v[2:])
 
 include_dirs = ['libBigWig', sysconfig.get_config_var("INCLUDEPY")]


### PR DESCRIPTION
* the output of subprocess (foo) is a byte-string, which on Python 2 compares fine with a string "-L", but not on Python 3
* changing the right side of the comparison with "-L" doesn't work because the propagated byte-strings then fail on the calls to distutils