### PR TITLE
 Add poweron architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+arch:
+  - amd64
+  - ppc64le
 python:
   - "3.5"
   - "3.6"


### PR DESCRIPTION
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly, 
we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.