### PR TITLE
Remove unused "dev" stats option.

### DIFF
--- a/libBigWig/README.md
+++ b/libBigWig/README.md
@@ -45,7 +45,7 @@ The only functions and structures that end users need to care about are in "bigW
 
         //Get an example statistic - standard deviation
         //We want ~4 bins in the range
-        stats = bwStats(fp, "chr1", 10000000, 10000100, 4, dev);
+        stats = bwStats(fp, "chr1", 10000000, 10000100, 4, std);
         if(stats) {
             printf("chr1:10000000-10000100 std. dev.: %f %f %f %f\n", stats[0], stats[1], stats[2], stats[3]);
             free(stats);

--- a/libBigWig/bigWig.h
+++ b/libBigWig/bigWig.h
@@ -105,7 +105,6 @@ enum bwStatsType {
     mean = 0, /*!< The mean value */
     average = 0, /*!< The mean value */
     stdev = 1, /*!< The standard deviation of the values */
-    dev = 1, /*!< The standard deviation of the values */
     max = 2, /*!< The maximum value */
     min = 3, /*!< The minimum value */
     cov = 4, /*!< The number of bases covered */

--- a/pyBigWig.c
+++ b/pyBigWig.c
@@ -364,7 +364,6 @@ error :
 enum bwStatsType char2enum(char *s) {
     if(strcmp(s, "mean") == 0) return mean;
     if(strcmp(s, "std") == 0) return stdev;
-    if(strcmp(s, "dev") == 0) return dev;
     if(strcmp(s, "max") == 0) return max;
     if(strcmp(s, "min") == 0) return min;
     if(strcmp(s, "cov") == 0) return cov;


### PR DESCRIPTION
There are references to a "dev" option in the stats function,
scattered throughout the code. It's not in the documentation
or in the implementation. This commit removes all of them.