### PR TITLE
Updated build and wheel distribution for pyBigWig

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,9 @@
-on: pull_request
+name: Test
+on: ["pull_request", "push"]
+
 jobs:
   testLinux:
-    name: TestLinux
+    name: Test Conda Linux
     runs-on: "ubuntu-latest"
     defaults:
       run:
@@ -17,3 +19,33 @@ jobs:
       - run: |
           pip install .
           nosetests -sv
+
+  test-builds:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.7'   
+    - name: Install build prerequisites
+      run: |
+        python -m pip install --upgrade build numpy
+    - name: Install cibuildwheel
+      run: |
+        python -m pip install --upgrade cibuildwheel      
+    - name: Build wheel(s)
+      run: |
+        python -m cibuildwheel --output-dir wheelhouse
+    - name: Build sdist
+      run: |
+        python -m build --sdist
+    - uses: actions/upload-artifact@v3
+      with:
+        name: pyBigWig-build
+        path: |
+          wheelhouse/*
+          dist/pyBigWig*.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Test
-on: ["pull_request", "push"]
+on: pull_request
 
 jobs:
   testLinux:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,5 +1,5 @@
 name: pypi
-on: [pull_request]
+on: [push]
 jobs:
   pypi:
     name: upload to pypi

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,5 +1,5 @@
 name: pypi
-on: [push]
+on: [pull_request]
 jobs:
   pypi:
     name: upload to pypi

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,0 @@
-include LICENSE.txt README.md *.c *.h setup.py
-include libBigWig/*
-include pyBigWigTest/*
-exclude pyBigWig.egg-info/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,45 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["oldest-supported-numpy", "setuptools", "setuptools-scm"]
+
+[project]
+authors = [{name = "Devon P. Ryan", email = "ryan@ie-freiburg.mpg.de"}]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved",
+  "Programming Language :: C",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Operating System :: POSIX",
+  "Operating System :: Unix",
+  "Operating System :: MacOS",
+]
+description = "A package for accessing bigWig files using libBigWig"
+dynamic = ["version"]
+keywords = ["bioinformatics", "bigWig", "bigBed"]
+name = "pyBigWig"
+readme = "README.md"
+requires-python = ">=3.7"
+
+[project.license]
+text = "MIT"
+
+[project.urls]
+"Bug Tracker" = "https://github.com/deeptools/pyBigWig/issues"
+"Download" = "https://pypi.python.org/pypi/pyBigWig"
+"Homepage" = "https://github.com/deeptools/pyBigWig"
+
+[tool.setuptools]
+# Override setuptools autodiscovery algorithm
+# Remove all package data/source specifically from wheel distribution
+include-package-data = false
+packages = []
+
+# Enable version inference from scm
+[tool.setuptools_scm]
+
+[tool.cibuildwheel]
+build = "cp37-manylinux_x86_64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,12 +34,13 @@ text = "MIT"
 
 [tool.setuptools]
 # Override setuptools autodiscovery algorithm
-# Remove all package data/source specifically from wheel distribution
-include-package-data = false
-packages = []
+# Only include package test data/source for wheel distribution
+include-package-data = true
+packages = ["pyBigWigTest"]
 
 # Enable version inference from scm
 [tool.setuptools_scm]
 
+# Target only minimum CPython version 3.7 on linux for wheel build
 [tool.cibuildwheel]
 build = "cp37-manylinux_x86_64"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
-[metadata]
-description-file = README.md
+# This is required for setuptools to name the wheel with the correct
+# minimum python abi version
+[bdist_wheel]
+py-limited-api = cp37


### PR DESCRIPTION
This pull request addresses Issue #133.

The changes do the following:
- Updates the build system to use pyproject.toml
- With setuptools_scm:
   - Files are tracked to be include in the source distribution
   - Versioning is based on git commit/tag
- Wheels (and the source distribution) are built through a build frontend such as [build](https://pypi.org/project/build/). Currently the wheels only target a minimum Python 3.7 ABI and Linux but could be modified
   - The wheels are assumed to be built in an environment where numpy is present to get the appropriate definitions and enable numpy features
   - Since wheels are installed by default, numpy is also assumed in this case to already be on the system
   - For users who do not want numpy features enabled, they would require the following:
      - A non-supported wheel Python version (2 or <3.7)
      - An explicit source install from pypi, github, etc

The github actions have been slightly modified to include artifacts being built and uploaded for verification from a pull request. See the bottom of [this action ](https://github.com/EricR86/pyBigWig/actions/runs/4264847206) on my fork for an example.

I have not yet tested but since the changes to the code (in setup.py) are minimal, it is very likely that a source distribution would still work on Python 2.7. I'm not certain if you would still like to support this version and it was excluded from the package metadata.

The numpy tests seem to be currently failing due to API deprecation issues. Other than that I cannot detect any regressions from this pull request.

Let me know if there's anything specifically you would like tuned or changed.