### PR TITLE
Add wheel to pypi upload in github actions

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -5,33 +5,30 @@ jobs:
     name: upload to pypi
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Setup conda
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.7'
+    - name: Install build prerequisites
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
       run: |
-        curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh
-        bash miniconda.sh -b -p $HOME/miniconda
-        export PATH="$HOME/miniconda/bin:$PATH"
-        hash -r
-        conda config --set always_yes yes --set changeps1 no
-    - name: create env
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-      run: |
-        export PATH=$HOME/miniconda/bin:$PATH
-        conda create -n foo -q --yes -c conda-forge -c bioconda python=3.7 twine numpy libcurl curl zlib
+        python -m pip install --upgrade twine build cibuildwheel numpy 
     - name: sdist
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
       run: |
-        export PATH=$HOME/miniconda/bin:$PATH
-        source activate foo
-        rm -f dist/*
-        python setup.py sdist
+        python -m build --sdist
+    - name: wheel
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      run: |
+        python -m cibuildwheel --output-dir wheelhouse
     - name: upload
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
       env:
         TWINE_USERNAME: "__token__"
         TWINE_PASSWORD: ${{ secrets.pypi_password }}
       run: |
-        export PATH=$HOME/miniconda/bin:$PATH
-        source activate foo
         twine upload dist/*
+        twine upload wheelhouse/*


### PR DESCRIPTION
Currently while there's mechanisms for a wheel build, it is not currently uploaded to pypi.

I've updated the current Github "upload to pypi" action with the following:
 - Removed building the sdist (and wheel) in a conda environment
 - Added uploading of wheel (built to the output directory of `wheelhouse`)
 - Ensure fetching of all git tags on checkout action

If there's something you'd prefer in terms of a github action to upload a wheel build let me know.