### PR TITLE
get np2 compatible

### DIFF
--- a/.environmentLinux.yaml
+++ b/.environmentLinux.yaml
@@ -7,7 +7,7 @@ dependencies:
   - gcc_linux-64
   - curl
   - zlib
-  - python 3.8
+  - python = 3.9
   - pip
   - numpy
-  - nose
+  - pytest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: Test
-on: pull_request
+on: 
+  pull_request:
+  push:
 
 jobs:
   testLinux:
@@ -14,11 +16,11 @@ jobs:
         with:
           activate-environment: foo
           environment-file: .environmentLinux.yaml
-          python-version: 3.8
+          python-version: 3.9
           auto-activate-base: false
       - run: |
           pip install .
-          nosetests -sv
+          pytest pyBigWigTest/test.py
 
   test-builds:
     runs-on: ubuntu-latest
@@ -30,7 +32,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'   
+        python-version: '3.9'   
     - name: Install build prerequisites
       run: |
         python -m pip install --upgrade build numpy

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.9'
     - name: Install build prerequisites
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
       run: |

--- a/pyBigWig.h
+++ b/pyBigWig.h
@@ -2,7 +2,7 @@
 #include <structmember.h>
 #include "bigWig.h"
 
-#define pyBigWigVersion "0.3.22"
+#define pyBigWigVersion "0.3.23"
 
 typedef struct {
     PyObject_HEAD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["oldest-supported-numpy", "setuptools", "setuptools-scm"]
+requires = ["numpy >= 2.0.0", "setuptools", "setuptools-scm"]
 
 [project]
 authors = [{name = "Devon P. Ryan", email = "dryan79@gmail.com"}]
@@ -11,7 +11,7 @@ classifiers = [
   "Programming Language :: C",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: Implementation :: CPython",
   "Operating System :: POSIX",
   "Operating System :: Unix",
@@ -20,9 +20,9 @@ classifiers = [
 description = "A package for accessing bigWig files using libBigWig"
 keywords = ["bioinformatics", "bigWig", "bigBed"]
 name = "pyBigWig"
-version = "0.3.22"
+version = "0.3.23"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 
 [project.license]
 text = "MIT"
@@ -41,9 +41,9 @@ packages = ["pyBigWigTest"]
 # Enable version inference from scm
 [tool.setuptools_scm]
 
-# Target only minimum CPython version 3.7 on linux for wheel build
+# Target only minimum CPython version 3.9 on linux for wheel build
 [tool.cibuildwheel]
-skip = "pp* cp36-* *-manylinux_i686 *_ppc64le *_s390x *-musllinux_x86_64 *-musllinux_i686"
+skip = "pp* cp38-* *-manylinux_i686 *_ppc64le *_s390x *-musllinux_x86_64 *-musllinux_i686"
 
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux2014"


### PR DESCRIPTION
Attempt to get compatibility with numpy 2.x.

Minimum python version is set to 3.9, and build system uses numpy 2.0.0 (or greater). Should be compatible with numpy 1.x as well. 

Got rid of nosetests in favor of pytest without changing the test layout.