### PR TITLE
pyBigWig.c: fix build failure with gcc 14.

### DIFF
--- a/pyBigWig.c
+++ b/pyBigWig.c
@@ -894,7 +894,7 @@ PyObject *pyBwAddHeader(pyBigWigFile_t *self, PyObject *args, PyObject *kwds) {
     }
 
     //Create the chromosome list
-    bw->cl = bwCreateChromList(chroms, lengths, n);
+    bw->cl = bwCreateChromList((const char * const*)chroms, lengths, n);
     if(!bw->cl) {
         PyErr_SetString(PyExc_RuntimeError, "Received an error in bwCreateChromList");
         goto error;
@@ -1248,7 +1248,7 @@ int PyAddIntervals(pyBigWigFile_t *self, PyObject *chroms, PyObject *starts, PyO
         if(PyErr_Occurred()) goto error;
     }
 
-    rv = bwAddIntervals(bw, cchroms, ustarts, uends, fvalues, n);
+    rv = bwAddIntervals(bw, (const char * const*)cchroms, ustarts, uends, fvalues, n);
     if(!rv) {
         self->lastTid = bwGetTid(bw, cchroms[n-1]);
         self->lastStart = uends[n-1];


### PR DESCRIPTION
As initially identified in [Debian bug #1075407], pyBigWig fails to build with gcc 14 with the following relevant output:

	pyBigWig.c:773:12: warning: return discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
	  773 |     return PyUnicode_AsUTF8(obj);
	      |            ^~~~~~~~~~~~~~~~~~~~~
	pyBigWig.c: In function ‘pyBwAddHeader’:
	pyBigWig.c:897:32: error: passing argument 1 of ‘bwCreateChromList’ from incompatible pointer type [-Wincompatible-pointer-types]
	  897 |     bw->cl = bwCreateChromList(chroms, lengths, n);
	      |                                ^~~~~~
	      |                                |
	      |                                char **
	In file included from pyBigWig.h:3,
	                 from pyBigWig.c:3:
	/usr/include/bigWig.h:497:51: note: expected ‘const char * const*’ but argument is of type ‘char **’
	  497 | chromList_t *bwCreateChromList(const char* const* chroms, const uint32_t *lengths, int64_t n);
	      |                                ~~~~~~~~~~~~~~~~~~~^~~~~~
	pyBigWig.c: In function ‘PyAddIntervals’:
	pyBigWig.c:1251:29: error: passing argument 2 of ‘bwAddIntervals’ from incompatible pointer type [-Wincompatible-pointer-types]
	 1251 |     rv = bwAddIntervals(bw, cchroms, ustarts, uends, fvalues, n);
	      |                             ^~~~~~~
	      |                             |
	      |                             char **
	/usr/include/bigWig.h:524:57: note: expected ‘const char * const*’ but argument is of type ‘char **’

This is because starting with gcc 14, incompatible pointer types are now fatal by default.  This patch fixes/workarounds the issue by casting affected pointers upon argument passing to function calls.

[Debian bug #1075407]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1075407