### PR TITLE
support bigWigs with lexicographically ordered chromosomes

### DIFF
--- a/libBigWig/bwStats.c
+++ b/libBigWig/bwStats.c
@@ -116,9 +116,10 @@ static struct vals_t *getVals(bigWigFile_t *fp, bwOverlapBlock_t *o, int i, uint
                 if(!v) goto error;
             }
             if(vstart > end) break;
-        } else if(vtid > tid) {
-            break;
         }
+        /* else if(vtid > tid) {
+            continue;
+        }*/
         p+=8;
     }
 

--- a/libBigWig/bwValues.c
+++ b/libBigWig/bwValues.c
@@ -134,8 +134,8 @@ static bwOverlapBlock_t *overlapsLeaf(bwRTreeNode_t *node, uint32_t tid, uint32_
     if(!o) return NULL;
 
     for(i=0; i<node->nChildren; i++) {
-        if(tid < node->chrIdxStart[i]) break;
-        if(tid > node->chrIdxEnd[i]) continue;
+        // if(tid < node->chrIdxStart[i]) break;
+        // if(tid > node->chrIdxEnd[i]) continue;
 
         /*
           The individual blocks can theoretically span multiple contigs.
@@ -149,6 +149,7 @@ static bwOverlapBlock_t *overlapsLeaf(bwRTreeNode_t *node, uint32_t tid, uint32_
                 if(node->baseEnd[i] <= start) continue;
             }
         } else {
+            if(tid != node->chrIdxStart[i]) continue;
             if(node->baseStart[i] >= end || node->baseEnd[i] <= start) continue;
         }
         o->n++;
@@ -161,8 +162,8 @@ static bwOverlapBlock_t *overlapsLeaf(bwRTreeNode_t *node, uint32_t tid, uint32_
         if(!o->size) goto error;
 
         for(i=0; i<node->nChildren; i++) {
-            if(tid < node->chrIdxStart[i]) break;
-            if(tid < node->chrIdxStart[i] || tid > node->chrIdxEnd[i]) continue;
+            // if(tid < node->chrIdxStart[i]) break;
+            // if(tid < node->chrIdxStart[i] || tid > node->chrIdxEnd[i]) continue;
             if(node->chrIdxStart[i] != node->chrIdxEnd[i]) {
                 if(tid == node->chrIdxStart[i]) {
                     if(node->baseStart[i] >= end) continue;
@@ -170,6 +171,7 @@ static bwOverlapBlock_t *overlapsLeaf(bwRTreeNode_t *node, uint32_t tid, uint32_
                     if(node->baseEnd[i] <= start) continue;
                 }
             } else {
+                if(tid != node->chrIdxStart[i]) continue;
                 if(node->baseStart[i] >= end || node->baseEnd[i] <= start) continue;
             }
             o->offset[idx] = node->dataOffset[i];
@@ -230,8 +232,8 @@ static bwOverlapBlock_t *overlapsNonLeaf(bigWigFile_t *fp, bwRTreeNode_t *node, 
     if(!output) return NULL;
 
     for(i=0; i<node->nChildren; i++) {
-        if(tid < node->chrIdxStart[i]) break;
-        if(tid < node->chrIdxStart[i] || tid > node->chrIdxEnd[i]) continue;
+        // if(tid < node->chrIdxStart[i]) break;
+        // if(tid < node->chrIdxStart[i] || tid > node->chrIdxEnd[i]) continue;
         if(node->chrIdxStart[i] != node->chrIdxEnd[i]) { //child spans contigs
             if(tid == node->chrIdxStart[i]) {
                 if(node->baseStart[i] >= end) continue;
@@ -239,6 +241,7 @@ static bwOverlapBlock_t *overlapsNonLeaf(bigWigFile_t *fp, bwRTreeNode_t *node, 
                 if(node->baseEnd[i] <= start) continue;
             }
         } else {
+            if(tid != node->chrIdxStart[i]) continue;
             if(end <= node->baseStart[i] || start >= node->baseEnd[i]) continue;
         }
 


### PR DESCRIPTION
This addresses #152.

- Completed pyBigWigTest successfully
- Fixed example from #152

-- Changes --
- Skipped all instances where loops were exited because the TID was thought to be surpassed, but it actually wasn't. This makes pyBigWig unnoticably slower, but more reliable.